### PR TITLE
Fixed build and test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 5.0.0
     - name: Install dependencies
       run: dotnet restore ElevatorChallenge.sln
     - name: Build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,8 +18,8 @@ jobs:
       with:
         dotnet-version: 3.1.301
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore ElevatorChallenge.sln
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build ElevatorChallenge.sln --configuration Release --no-restore
     - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      run: dotnet test ElevatorChallenge.sln --no-restore --verbosity normal


### PR DESCRIPTION
Build and test workflow failed because there were more project files than only one .sln file inside the current directory.